### PR TITLE
<fix>修改：在yaml总配置rpc target，不能读取url所携带的参数问题

### DIFF
--- a/zrpc/registry/nacos/builder.go
+++ b/zrpc/registry/nacos/builder.go
@@ -3,15 +3,13 @@ package nacos
 import (
 	"context"
 	"fmt"
-	"net"
-	"strconv"
-	"strings"
-
 	"github.com/nacos-group/nacos-sdk-go/clients"
 	"github.com/nacos-group/nacos-sdk-go/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/vo"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/resolver"
+	"net"
+	"strconv"
 )
 
 func init() {
@@ -26,7 +24,7 @@ const schemeName = "nacos"
 type builder struct{}
 
 func (b *builder) Build(url resolver.Target, conn resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
-	dsn := strings.Join([]string{schemeName + ":/", url.Authority, url.Endpoint}, "/")
+	dsn := url.URL.Scheme + "://" + url.URL.Host + url.URL.RequestURI()
 	tgt, err := parseURL(dsn)
 	if err != nil {
 		return nil, errors.Wrap(err, "Wrong nacos URL")


### PR DESCRIPTION
比如：nacos://192.168.0.135:8848/user.rpc?namespaceid=9aab54de-6155-4dc5-be84-580cb5364575&timeout=5000s&User=nacos&Password=nacos
能读取到：namespaceid、timeout、User、Password