### PR TITLE
fix: close nacos client with resolver

### DIFF
--- a/zrpc/registry/nacos/builder.go
+++ b/zrpc/registry/nacos/builder.go
@@ -80,7 +80,10 @@ func (b *builder) Build(url resolver.Target, conn resolver.ClientConn, opts reso
 
 	go populateEndpoints(ctx, conn, pipe)
 
-	return &resolvr{cancelFunc: cancel}, nil
+	return &resolvr{
+		cancelFunc: cancel,
+		client:     cli,
+	}, nil
 }
 
 // Scheme returns the scheme supported by this resolver.

--- a/zrpc/registry/nacos/resolver.go
+++ b/zrpc/registry/nacos/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/common/logger"
 	"github.com/nacos-group/nacos-sdk-go/v2/model"
@@ -13,13 +14,20 @@ import (
 
 type resolvr struct {
 	cancelFunc context.CancelFunc
+	client     interface {
+		CloseClient()
+	}
+	closeOnce sync.Once
 }
 
 func (r *resolvr) ResolveNow(resolver.ResolveNowOptions) {}
 
 // Close closes the resolver.
 func (r *resolvr) Close() {
-	r.cancelFunc()
+	r.closeOnce.Do(func() {
+		r.cancelFunc()
+		r.client.CloseClient()
+	})
 }
 
 type watcher struct {
@@ -49,7 +57,10 @@ func (nw *watcher) CallBackHandle(services []model.Instance, err error) {
 			ee = append(ee, fmt.Sprintf("%s:%d", s.Ip, s.Port))
 		}
 	}
-	nw.out <- ee
+	select {
+	case nw.out <- ee:
+	case <-nw.ctx.Done():
+	}
 }
 
 func populateEndpoints(ctx context.Context, clientConn resolver.ClientConn, input <-chan []string) {

--- a/zrpc/registry/nacos/resolver_test.go
+++ b/zrpc/registry/nacos/resolver_test.go
@@ -1,0 +1,68 @@
+package nacos
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nacos-group/nacos-sdk-go/v2/model"
+)
+
+type testNamingClient struct {
+	mu         sync.Mutex
+	closeCalls int
+}
+
+func (c *testNamingClient) CloseClient() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closeCalls++
+}
+
+func (c *testNamingClient) CloseCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closeCalls
+}
+
+func TestResolverCloseClosesNamingClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &testNamingClient{}
+	r := &resolvr{
+		cancelFunc: cancel,
+		client:     client,
+	}
+
+	r.Close()
+	r.Close()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("resolver context was not canceled")
+	}
+
+	if got := client.CloseCalls(); got != 1 {
+		t.Fatalf("CloseClient called %d times, want 1", got)
+	}
+}
+
+func TestWatcherCallbackReturnsWhenResolverIsClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	watcher := newWatcher(ctx, cancel, make(chan []string))
+	done := make(chan struct{})
+
+	go func() {
+		watcher.CallBackHandle([]model.Instance{{Ip: "127.0.0.1", Port: 8080}}, nil)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher callback did not return after resolver shutdown")
+	}
+}


### PR DESCRIPTION
Fixes #334

Close the Nacos naming client when gRPC closes its resolver, preventing subscriptions from continuing to receive Nacos push events after the resolver has been released.

Also make watcher callbacks exit cleanly after resolver shutdown and add regression coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR ties each Nacos naming client to its resolver lifecycle so resolver shutdown cancels endpoint processing and closes the client exactly once.
- Stores the naming client on the resolver and closes it during resolver shutdown.
- Makes resolver shutdown idempotent with `sync.Once`.
- Allows watcher callbacks blocked on endpoint delivery to exit after cancellation.
- Adds regression tests for client closure and callback shutdown.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with resolver-owned resources now released cleanly and idempotently.

Each resolver receives a newly created naming client, closes that client exactly once after canceling its processing context, and allows blocked watcher callbacks to observe cancellation; no concrete blocking or non-blocking issue remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| zrpc/registry/nacos/builder.go | Associates the newly created Nacos naming client with the resolver that exclusively owns its lifecycle. |
| zrpc/registry/nacos/resolver.go | Adds idempotent client shutdown and cancellation-aware watcher delivery without an identified actionable defect. |
| zrpc/registry/nacos/resolver_test.go | Covers exactly-once client closure, context cancellation, and callback completion after shutdown. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant gRPC
    participant Resolver
    participant Context
    participant Watcher
    participant Nacos
    gRPC->>Resolver: Close()
    Resolver->>Context: cancel()
    Context-->>Watcher: Done()
    Watcher-->>Watcher: Exit blocked callback
    Resolver->>Nacos: CloseClient()
    Note over Resolver,Nacos: sync.Once makes shutdown idempotent
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: close nacos client with resolver"](https://github.com/zeromicro/zero-contrib/commit/caf10d0ebc7d66d5116c4b71813e2a48cd3ae4de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55223613)</sub>

<!-- /greptile_comment -->